### PR TITLE
fix "invalid byte sequence in US-ASCII"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir /usr/src/app
 
 WORKDIR /usr/src/app
 
+ENV RUBYOPT -EUTF-8
+
 COPY Gemfile /usr/src/app/Gemfile
 COPY Gemfile.lock /usr/src/app/Gemfile.lock
 RUN bundle install


### PR DESCRIPTION
add RUBYOPT to set Encoding.default_external as UTF-8

#23 を修正するものです。