### PR TITLE
CI: Update image (Ubuntu 18.04 -> 20.04, Ruby 2.5.5 -> 2.6.8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   deploy:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.5.5-node-browsers
+       - image: circleci/ruby:2.6.8-browsers
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/


### PR DESCRIPTION
cfj-hackday_websiteで "deploy job failed." が続いているようなので、修正してみます。

https://app.circleci.com/pipelines/github/codeforjapan/socialhackday/574/workflows/17eed66d-849c-4b88-a928-ef4d61e7cd24/jobs/1292

ログを見た限りでは `bundle install` は成功しているけど `sudo apt-get update -yqqq` で失敗して、`npm install` までは行っていなさそうです。
なんとなくdebianのdeb repositoryを見に行って失敗しているようなので（最近Debian 11がリリースされたのが影響しているのかも）、もう少し新し目のUbuntuを使っているimageにしてみます。

この修正ではダメそうでしたら `circleci/ruby:2.5.9-browsers` か `circleci/ruby:2.5.9-node-browsers` 辺りにしてみると良いかもしれません。とはいえRuby 2.5系はサポート終了なので上げられるなら上げておきたいところです。